### PR TITLE
Remove unnecessary docker scripts:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
             - openssh-client
 
 install:
-    - ./build.sh
-    - ./run.sh
+    - docker build -t aiida-docker-base .
+    - docker run -d aiida-docker-base
 
 # I just run a command with verdi that returns a zero error code to see if
 # verdi is installed properly

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
 # verdi is installed properly
 script:
     - sleep 30 # wait 30 seconds till the container is ready
-    - "export DOCKERID=`docker ps -qf 'ancestor=aiidateam/aiida-docker-base'`"
+    - "export DOCKERID=`docker ps -qf 'ancestor=aiida-docker-base'`"
     - "echo \"Docker ID: $DOCKERID\""
     - "docker exec --tty --user aiida \"$DOCKERID\" /bin/bash -l -c 'verdi'"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The docker image contains:
 
 The docker image is built automatically on Docker Hub once new changes are pushed to the `master` or `develop` branches of this repository.
 The `master` branch is available under the docker tag `latest`, while the `develop` branch is available under the docker tag `develop`.
-In addition to that any new version tag that is pushed to the repository will trigger Docker Hub to build the image with the same tag as on the GitHub.
+In addition, any git tag pushed to the repository will trigger a build on Docker Hub with the same docker tag.
 
 All the images are available following this link: https://hub.docker.com/r/aiidateam/aiida-docker-base.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The docker image contains:
 
 # Docker Hub repository
 
-The docker image is built automatically on Docker Hub once new changes were pushed to the `master` or `develop` branches of the corresponding GitHub repository.
+The docker image is built automatically on Docker Hub once new changes are pushed to the `master` or `develop` branches of this repository.
 The image pushed to the `master` will be tagged as `latest`, the image pushed to the `develop` branch will be tagged as `develop`.
 In addition to that any new version tag that is pushed to the repository will trigger Docker Hub to build the image with the same tag as on the GitHub.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The docker image contains:
 # Docker Hub repository
 
 The docker image is built automatically on Docker Hub once new changes are pushed to the `master` or `develop` branches of this repository.
-The image pushed to the `master` will be tagged as `latest`, the image pushed to the `develop` branch will be tagged as `develop`.
+The `master` branch is available under the docker tag `latest`, while the `develop` branch is available under the docker tag `develop`.
 In addition to that any new version tag that is pushed to the repository will trigger Docker Hub to build the image with the same tag as on the GitHub.
 
 All the images are available following this link: https://hub.docker.com/r/aiidateam/aiida-docker-base.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,9 @@ In order to update the AiiDA version, go to Docker file and change the following
 RUN pip3 install aiida-core[ ... ]==vX.Y.Z
 
 ```
-Adapt X.Y.Z numbers to the latest AiiDA version. Once this is done,
-run the following commands:
+Adapt X.Y.Z numbers to the latest AiiDA version.
 
-```
-./build.sh # to build the new aiida-docker-base image locally and tag it as 'latest'
-./tag.sh # to specify the AiiDA version number as the image's tag
-./push.sh # to push the image tagged with the version number to the Docker Hub
-./push_latest.sh # to push the image tagged with 'latest' to the Docker Hub
-```
+## Docker image
 
 The docker image contains:
  * minimal Ubuntu base image (phusion/baseimage)
@@ -28,10 +22,11 @@ The docker image contains:
 
 # Docker Hub repository
 
-The corresponding docker image is built automatically on Docker Hub:
+The docker image is built automatically on Docker Hub once new changes were pushed to the `master` or `develop` branches of the corresponding GitHub repository.
+The image pushed to the `master` will be tagged as `latest`, the image pushed to the `develop` branch will be tagged as `develop`.
+In addition to that any new version tag that is pushed to the repository will trigger Docker Hub to build the image with the same tag as on the GitHub.
 
-https://hub.docker.com/r/aiidateam/aiida-docker-base
-
+All the images are available following this link: https://hub.docker.com/r/aiidateam/aiida-docker-base.
 
 # Acknowledgements
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-set -x
-
-docker build -t aiidateam/aiida-docker-base:latest ./
-
-#EOF

--- a/push.sh
+++ b/push.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-set -x
-
-VERSION="$(grep 'install aiida' Dockerfile | cut -d'=' -f3)"
-
-docker push aiidateam/aiida-docker-base:${VERSION}
-
-#EOF

--- a/push_latest.sh
+++ b/push_latest.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-set -x
-
-docker push aiidateam/aiida-docker-base:latest
-
-#EOF

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,0 @@
-#!/bin/bash -e
-
-set -x
-
-docker run -d aiidateam/aiida-docker-base:latest
-
-#EOF

--- a/tag.sh
+++ b/tag.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -e
-
-set -x
-
-VERSION="$(grep 'install aiida' Dockerfile | cut -d'=' -f3)"
-
-docker tag aiidateam/aiida-docker-base:latest aiidateam/aiida-docker-base:${VERSION}
-
-#EOF


### PR DESCRIPTION
1) Remove build.sh, push.sh, tag.sh, etc are not needed anymore since
from now on the image will be build automatically on Docker Hub.
2) adapt readme accordingly
3) adapt .travis.yml accordingly